### PR TITLE
Update docs to point to public CLI release

### DIFF
--- a/.github/workflows/runcliwhl.yml
+++ b/.github/workflows/runcliwhl.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: 3.7
     - run: |
-        az extension add --source https://azuremlsdktestpypi.blob.core.windows.net/wheels/sdk-cli-v2/ml-0.0.64-py3-none-any.whl --pip-extra-index-urls https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2 -y
+        az extension add --source https://azuremlsdktestpypi.blob.core.windows.net/wheels/sdk-cli-v2-public/ml-1.0.0a1-py3-none-any.whl --pip-extra-index-urls https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2-public -y
         # NOTE: If the above line number is changed (currently #25), please update installation.rst (cli install instructions is pulled from here)
     - run: az ml -h
     - run: az ml job -h


### PR DESCRIPTION
pointing install docs at release candidate 1.0.0a1

# PR into Azure/azureml-v2-preview

## Checklist

I have:

- [x] read and followed the contributing guidelines

## Changes

- Updating install instructions to point at the first public alpha release

Fixes #
